### PR TITLE
Tentative fix for i3 focus_follows_mouse issue.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ pub struct RenderWindow<'a> {
     cairo_context: cairo::Context,
     draw_pos: (f64, f64),
     rect: (i32, i32, i32, i32),
+    xcb_window_id: u32,
 }
 
 #[derive(Debug)]
@@ -231,6 +232,7 @@ fn main() {
             cairo_context,
             draw_pos,
             rect: (x.into(), y.into(), width.into(), height.into()),
+            xcb_window_id,
         };
 
         render_windows.insert(hint, render_window);
@@ -303,6 +305,11 @@ fn main() {
                             if app_config.print_only {
                                 println!("0x{:x}", rw.desktop_window.x_window_id.unwrap_or(0));
                             } else {
+
+                                for (_, rwd) in &render_windows {
+                                    xcb::unmap_window(&conn, rwd.xcb_window_id);
+                                }
+                                conn.flush();
                                 wm::focus_window(&rw.desktop_window);
                             }
                             closed = true;


### PR DESCRIPTION
In i3 with focus_follows_mouse enabled, wmfocus would seemingly fail to put the
focus on windows that did not contain the mouse pointer. By adding in delays in
the process and checking the logs, it seems like there is "mouse enter" event
that occurs in the desktop windows *after* the hint window is
unmapped/destroyed. Since the hint windows were destroyed after focus was placed
on the desktop window, this resulted in focus being placed in the window under
the mouse cursor even if this was not the window selected in wmfocus.

The fix here unmaps the hint windows *before* focus is placed on the selected
desktop window. This seems to work OK but I'm not sure it's the best solution.
There could be a race like the following: Once the hint windows are unmapped,
i3/X replaces the mouse cursor and generates the "mouse enter" event either
before or after wm::focus is called. Maybe this is not a huge issue.