### PR TITLE
Edge offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ OPTIONS:
                                            sadfjklewcmpgh]
     -m, --margin <margin>                  Add an additional margin around the text box (value is a factor of the box
                                            size) [default: 0.2]
+    -o, --offset <offset>                  Offset box from edge of window (x,y) [default: 0,0]
 ```
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,8 @@ pub struct AppConfig {
     pub print_only: bool,
     pub horizontal_align: utils::HorizontalAlign,
     pub vertical_align: utils::VerticalAlign,
+    pub xoff: f64,
+    pub yoff: f64,
 }
 
 #[cfg(any(feature = "i3", feature = "add_some_other_wm_here"))]
@@ -107,6 +109,9 @@ fn main() {
             )
         };
 
+        let xoff = app_config.xoff as i16;
+        let yoff = app_config.yoff as i16;
+
         // Due to the way cairo lays out text, we'll have to calculate the actual coordinates to
         // put the cursor. See:
         // https://www.cairographics.org/samples/text_align_center/
@@ -123,22 +128,22 @@ fn main() {
         );
 
         let mut x = match app_config.horizontal_align {
-            utils::HorizontalAlign::Left => desktop_window.pos.0 as i16,
+            utils::HorizontalAlign::Left => (desktop_window.pos.0 + i32::from(xoff)) as i16,
             utils::HorizontalAlign::Center => {
                 (desktop_window.pos.0 + desktop_window.size.0 / 2 - i32::from(width) / 2) as i16
             }
             utils::HorizontalAlign::Right => {
-                (desktop_window.pos.0 + desktop_window.size.0 - i32::from(width)) as i16
+                (desktop_window.pos.0 + desktop_window.size.0 - i32::from(width) - i32::from(xoff)) as i16
             }
         };
 
         let y = match app_config.vertical_align {
-            utils::VerticalAlign::Top => desktop_window.pos.1 as i16,
+            utils::VerticalAlign::Top => (desktop_window.pos.1 + i32::from(yoff)) as i16,
             utils::VerticalAlign::Center => {
                 (desktop_window.pos.1 + desktop_window.size.1 / 2 - i32::from(height) / 2) as i16
             }
             utils::VerticalAlign::Bottom => {
-                (desktop_window.pos.1 + desktop_window.size.1 - i32::from(height)) as i16
+                (desktop_window.pos.1 + desktop_window.size.1 - i32::from(height) - i32::from(yoff)) as i16
             }
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,25 +124,25 @@ fn main() {
             desktop_window
         );
 
-        let xoff = app_config.x_offset;
+        let x_offset = app_config.x_offset;
         let mut x = match app_config.horizontal_align {
-            utils::HorizontalAlign::Left => (desktop_window.pos.0 + xoff) as i16,
+            utils::HorizontalAlign::Left => (desktop_window.pos.0 + x_offset) as i16,
             utils::HorizontalAlign::Center => {
                 (desktop_window.pos.0 + desktop_window.size.0 / 2 - i32::from(width) / 2) as i16
             }
             utils::HorizontalAlign::Right => {
-                (desktop_window.pos.0 + desktop_window.size.0 - i32::from(width) - xoff) as i16
+                (desktop_window.pos.0 + desktop_window.size.0 - i32::from(width) - x_offset) as i16
             }
         };
 
-        let yoff = app_config.y_offset;
+        let y_offset = app_config.y_offset;
         let y = match app_config.vertical_align {
-            utils::VerticalAlign::Top => (desktop_window.pos.1 + yoff) as i16,
+            utils::VerticalAlign::Top => (desktop_window.pos.1 + y_offset) as i16,
             utils::VerticalAlign::Center => {
                 (desktop_window.pos.1 + desktop_window.size.1 / 2 - i32::from(height) / 2) as i16
             }
             utils::VerticalAlign::Bottom => {
-                (desktop_window.pos.1 + desktop_window.size.1 - i32::from(height) - yoff) as i16
+                (desktop_window.pos.1 + desktop_window.size.1 - i32::from(height) - y_offset) as i16
             }
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,8 @@ pub struct AppConfig {
     pub print_only: bool,
     pub horizontal_align: utils::HorizontalAlign,
     pub vertical_align: utils::VerticalAlign,
-    pub xoff: f64,
-    pub yoff: f64,
+    pub x_offset: i32,
+    pub y_offset: i32,
 }
 
 #[cfg(any(feature = "i3", feature = "add_some_other_wm_here"))]
@@ -109,9 +109,6 @@ fn main() {
             )
         };
 
-        let xoff = app_config.xoff as i16;
-        let yoff = app_config.yoff as i16;
-
         // Due to the way cairo lays out text, we'll have to calculate the actual coordinates to
         // put the cursor. See:
         // https://www.cairographics.org/samples/text_align_center/
@@ -127,23 +124,25 @@ fn main() {
             desktop_window
         );
 
+        let xoff = app_config.x_offset;
         let mut x = match app_config.horizontal_align {
-            utils::HorizontalAlign::Left => (desktop_window.pos.0 + i32::from(xoff)) as i16,
+            utils::HorizontalAlign::Left => (desktop_window.pos.0 + xoff) as i16,
             utils::HorizontalAlign::Center => {
                 (desktop_window.pos.0 + desktop_window.size.0 / 2 - i32::from(width) / 2) as i16
             }
             utils::HorizontalAlign::Right => {
-                (desktop_window.pos.0 + desktop_window.size.0 - i32::from(width) - i32::from(xoff)) as i16
+                (desktop_window.pos.0 + desktop_window.size.0 - i32::from(width) - xoff) as i16
             }
         };
 
+        let yoff = app_config.y_offset;
         let y = match app_config.vertical_align {
-            utils::VerticalAlign::Top => (desktop_window.pos.1 + i32::from(yoff)) as i16,
+            utils::VerticalAlign::Top => (desktop_window.pos.1 + yoff) as i16,
             utils::VerticalAlign::Center => {
                 (desktop_window.pos.1 + desktop_window.size.1 / 2 - i32::from(height) / 2) as i16
             }
             utils::VerticalAlign::Bottom => {
-                (desktop_window.pos.1 + desktop_window.size.1 - i32::from(height) - i32::from(yoff)) as i16
+                (desktop_window.pos.1 + desktop_window.size.1 - i32::from(height) - yoff) as i16
             }
         };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,16 +79,16 @@ fn is_valid_color(c: String) -> Result<(), String> {
 }
 
 /// Validate coordinates.
-fn is_valid_coord(g: String) -> Result<(), String> {
-    let v: Vec<_> = g.split(',').collect();
-    let (xoff, yoff) = (v.get(0), v.get(1));
-    if xoff.is_none() || yoff.is_none() {
+fn is_valid_coord(c: String) -> Result<(), String> {
+    let v: Vec<_> = c.split(',').collect();
+    let (x, y) = (v.get(0), v.get(1));
+    if x.is_none() || y.is_none() {
         return Err("Expected x,y coordinates".to_string());
     }
-    if let Err(e) = xoff.unwrap().parse::<f32>() {
+    if let Err(e) = x.unwrap().parse::<i32>() {
         return Err(e.description().to_string());
     }
-    if let Err(e) = yoff.unwrap().parse::<f32>() {
+    if let Err(e) = y.unwrap().parse::<i32>() {
         return Err(e.description().to_string());
     }
     Ok(())
@@ -161,7 +161,7 @@ pub fn parse_args() -> AppConfig {
             .takes_value(true)
             .validator(is_valid_coord)
             .default_value("0,0")
-            .display_order(45)
+            .display_order(103)
             .help("Offset from window edge (x,y)"))
         .arg(
             Arg::with_name("text_color")
@@ -223,7 +223,7 @@ pub fn parse_args() -> AppConfig {
     let margin = value_t!(matches, "margin", f32).unwrap();
     let offset = value_t!(matches, "offset", String).unwrap();
     let v: Vec<_> = offset.split(',').collect();
-    let (xoff, yoff) = (v[0].parse::<f64>().unwrap(), v[1].parse::<f64>().unwrap());
+    let (x_offset, y_offset) = (v[0].parse::<i32>().unwrap(), v[1].parse::<i32>().unwrap());
     let text_color_unparsed = value_t!(matches, "text_color", CssColor).unwrap();
     let text_color = parse_color(text_color_unparsed);
     let text_color_alt_unparsed = value_t!(matches, "text_color_alt", CssColor).unwrap();
@@ -256,8 +256,8 @@ pub fn parse_args() -> AppConfig {
         print_only,
         horizontal_align,
         vertical_align,
-        xoff,
-        yoff,
+        x_offset,
+        y_offset,
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -162,7 +162,7 @@ pub fn parse_args() -> AppConfig {
             .allow_hyphen_values(true)
             .validator(is_valid_coord)
             .default_value("0,0")
-            .help("Offset box from edge of window (x,y)"))
+            .help("Offset box from edge of window relative to alignment (x,y)"))
         .arg(
             Arg::with_name("text_color")
             .long("textcolor")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -159,6 +159,7 @@ pub fn parse_args() -> AppConfig {
             .short("o")
             .long("offset")
             .takes_value(true)
+            .allow_hyphen_values(true)
             .validator(is_valid_coord)
             .default_value("0,0")
             .help("Offset box from edge of window (x,y)"))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -161,8 +161,7 @@ pub fn parse_args() -> AppConfig {
             .takes_value(true)
             .validator(is_valid_coord)
             .default_value("0,0")
-            .display_order(103)
-            .help("Offset from window edge (x,y)"))
+            .help("Offset box from edge of window (x,y)"))
         .arg(
             Arg::with_name("text_color")
             .long("textcolor")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,6 +78,22 @@ fn is_valid_color(c: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Validate coordinates.
+fn is_valid_coord(g: String) -> Result<(), String> {
+    let v: Vec<_> = g.split(',').collect();
+    let (xoff, yoff) = (v.get(0), v.get(1));
+    if xoff.is_none() || yoff.is_none() {
+        return Err("Expected x,y coordinates".to_string());
+    }
+    if let Err(e) = xoff.unwrap().parse::<f32>() {
+        return Err(e.description().to_string());
+    }
+    if let Err(e) = yoff.unwrap().parse::<f32>() {
+        return Err(e.description().to_string());
+    }
+    Ok(())
+}
+
 /// Load a system font.
 fn load_font(font_family: &str) -> Vec<u8> {
     let font_family_property = system_fonts::FontPropertyBuilder::new()
@@ -139,6 +155,15 @@ pub fn parse_args() -> AppConfig {
             .default_value("0.2")
             .help("Add an additional margin around the text box (value is a factor of the box size)"))
         .arg(
+            Arg::with_name("offset")
+            .short("o")
+            .long("offset")
+            .takes_value(true)
+            .validator(is_valid_coord)
+            .default_value("0,0")
+            .display_order(45)
+            .help("Offset from window edge (x,y)"))
+        .arg(
             Arg::with_name("text_color")
             .long("textcolor")
             .takes_value(true)
@@ -181,7 +206,7 @@ pub fn parse_args() -> AppConfig {
         .arg(
             Arg::with_name("fill")
             .long("fill")
-            .conflicts_with_all(&["horizontal_align", "vertical_align", "margin"])
+            .conflicts_with_all(&["horizontal_align", "vertical_align", "margin", "offset"])
             .display_order(102)
             .help("Completely fill out windows"))
         .arg(
@@ -196,6 +221,9 @@ pub fn parse_args() -> AppConfig {
     let (font_family, font_size) = (v[0].to_string(), v[1].parse::<f64>().unwrap());
     let hint_chars = value_t!(matches, "hint_chars", String).unwrap();
     let margin = value_t!(matches, "margin", f32).unwrap();
+    let offset = value_t!(matches, "offset", String).unwrap();
+    let v: Vec<_> = offset.split(',').collect();
+    let (xoff, yoff) = (v[0].parse::<f64>().unwrap(), v[1].parse::<f64>().unwrap());
     let text_color_unparsed = value_t!(matches, "text_color", CssColor).unwrap();
     let text_color = parse_color(text_color_unparsed);
     let text_color_alt_unparsed = value_t!(matches, "text_color_alt", CssColor).unwrap();
@@ -228,6 +256,8 @@ pub fn parse_args() -> AppConfig {
         print_only,
         horizontal_align,
         vertical_align,
+        xoff,
+        yoff,
     }
 }
 


### PR DESCRIPTION
This adds the `--offset` option. Works as expected with `--halign` and `--valign` except when set to center, the corresponding offset is ignored.