### PR TITLE
Add Sway support as separate feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,20 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -650,6 +664,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "swayipc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40cc7e2bba9f31e7c46b119d9c542496806b9114676d8f46aa5c9c950ececaec"
+dependencies = [
+ "serde",
+ "serde_json",
+ "swayipc-types",
+]
+
+[[package]]
+name = "swayipc-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d63c88513504fd598a6c2218bd83d19e1f8cc6dd1a9892f2f982b223f01a803"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "syn"
@@ -796,6 +832,7 @@ dependencies = [
  "log",
  "pretty_env_logger",
  "regex",
+ "swayipc",
  "x11",
  "xcb",
  "xcb-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ codegen-units = 1
 
 [features]
 i3 = ["i3ipc"]
+sway = ["swayipc"]
 
 [dependencies]
 cairo-sys-rs = "0.15"
 css-color-parser = "0.1"
 font-loader = "0.11"
 i3ipc = { version = "0.10", optional = true }
+swayipc = { version = "3.0.0", optional = true }
 itertools = "0.10"
 log = "0.4"
 pretty_env_logger = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use xkbcommon::xkb;
 mod args;
 mod utils;
 
+// begin i3-specific
+
 #[cfg(feature = "i3")]
 extern crate i3ipc;
 
@@ -17,10 +19,25 @@ mod wm_i3;
 #[cfg(feature = "i3")]
 use crate::wm_i3 as wm;
 
+// end i3-specific
+
+// begin sway-specific
+
+#[cfg(feature = "sway")]
+extern crate swayipc;
+
+#[cfg(feature = "sway")]
+mod wm_sway;
+
+#[cfg(feature = "sway")]
+use crate::wm_sway as wm;
+
+// end sway-specific
+
 #[derive(Debug)]
 pub struct DesktopWindow {
     id: i64,
-    x_window_id: Option<i32>,
+    x_window_id: Option<i64>,
     pos: (i32, i32),
     size: (i32, i32),
     is_focused: bool,
@@ -34,7 +51,7 @@ pub struct RenderWindow<'a> {
     rect: (i32, i32, i32, i32),
 }
 
-#[cfg(any(feature = "i3", feature = "add_some_other_wm_here"))]
+#[cfg(any(feature = "i3", feature = "sway"))]
 fn main() -> Result<()> {
     pretty_env_logger::init();
     let app_config = args::parse_args();
@@ -325,12 +342,13 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(any(feature = "i3", feature = "add_some_other_wm_here")))]
+#[cfg(not(any(feature = "i3", feature = "sway")))]
 fn main() -> Result<()> {
     eprintln!(
-        "You need to enable support for at least one window manager.\n
+        "You need to enable support for one window manager.\n
 Currently supported:
-    --features i3"
+    --features i3
+    --features sway"
     );
 
     Ok(())

--- a/src/wm_sway.rs
+++ b/src/wm_sway.rs
@@ -1,0 +1,120 @@
+use anyhow::{Context, Result};
+use log::{debug, info};
+use swayipc::{Connection, Node, NodeLayout, NodeType, Workspace};
+
+use crate::DesktopWindow;
+
+/// Find first `Node` that fulfills a given criterion.
+fn find_first_node_with_attr<F>(start_node: &Node, predicate: F) -> Option<&Node>
+where
+    F: Fn(&Node) -> bool,
+{
+    let mut nodes_to_explore: Vec<&Node> = start_node.nodes.iter().collect();
+    while !nodes_to_explore.is_empty() {
+        let mut next_vec = vec![];
+        for node in &nodes_to_explore {
+            if predicate(node) {
+                return Some(node);
+            }
+            next_vec.extend(node.nodes.iter());
+        }
+        nodes_to_explore = next_vec;
+    }
+    None
+}
+
+/// Find parent of `child`.
+fn find_parent_of<'a>(start_node: &'a Node, child: &'a Node) -> Option<&'a Node> {
+    let mut nodes_to_explore: Vec<&Node> = start_node.nodes.iter().collect();
+    while !nodes_to_explore.is_empty() {
+        let mut next_vec = vec![];
+        for node in &nodes_to_explore {
+            if node.nodes.iter().any(|x| child.id == x.id) {
+                return Some(node);
+            }
+            next_vec.extend(node.nodes.iter());
+        }
+        nodes_to_explore = next_vec;
+    }
+    None
+}
+
+/// Return a list of all `DesktopWindow`s for the given `Workspace`.
+fn crawl_windows(root_node: &Node, workspace: &Workspace) -> Result<Vec<DesktopWindow>> {
+    let workspace_node = find_first_node_with_attr(root_node, |x| {
+        x.name == Some(workspace.name.clone()) && x.node_type == NodeType::Workspace
+    })
+    .context("Couldn't find the Workspace node")?;
+
+    let mut nodes_to_explore: Vec<&Node> = workspace_node.nodes.iter().collect();
+    nodes_to_explore.extend(workspace_node.floating_nodes.iter());
+    let mut windows = vec![];
+    while !nodes_to_explore.is_empty() {
+        let mut next_vec = vec![];
+        for node in &nodes_to_explore {
+            next_vec.extend(node.nodes.iter());
+            next_vec.extend(node.floating_nodes.iter());
+
+            let root_node = find_parent_of(root_node, node);
+
+            let (pos_x, size_x) = if let Some(root_node) = root_node {
+                if root_node.layout == NodeLayout::Tabbed {
+                    (node.rect.x + node.deco_rect.x, node.deco_rect.width)
+                } else {
+                    (node.rect.x, node.rect.width)
+                }
+            } else {
+                (node.rect.x, node.rect.width)
+            };
+
+            let pos_y = if let Some(root_node) = root_node {
+                if root_node.layout == NodeLayout::Stacked {
+                    root_node.rect.y + node.deco_rect.y
+                } else {
+                    node.rect.y - node.deco_rect.height
+                }
+            } else {
+                node.rect.y - node.deco_rect.height
+            };
+
+            let window = DesktopWindow {
+                id: node.id,
+                x_window_id: node.window,
+                pos: (pos_x, pos_y),
+                size: (size_x, (node.rect.height + node.deco_rect.height)),
+                is_focused: node.focused,
+            };
+            debug!("Found {:?}", window);
+            windows.push(window);
+        }
+        nodes_to_explore = next_vec;
+    }
+    Ok(windows)
+}
+
+/// Return a list of all windows.
+pub fn get_windows() -> Result<Vec<DesktopWindow>> {
+    // Establish a connection to Sway over a Unix socket
+    let mut connection = Connection::new().expect("Couldn't acquire Sway IPC connection");
+    let workspaces = connection
+        .get_workspaces()
+        .expect("Problem communicating with IPC");
+    let visible_workspaces = workspaces.iter().filter(|w| w.visible);
+    let root_node = connection.get_tree()?;
+    let mut windows = vec![];
+    for workspace in visible_workspaces {
+        windows.extend(crawl_windows(&root_node, workspace)?);
+    }
+    Ok(windows)
+}
+
+/// Focus a specific `window`.
+pub fn focus_window(window: &DesktopWindow) -> Result<()> {
+    let mut connection = Connection::new().expect("Couldn't acquire Sway IPC connection");
+    let command_str = format!("[con_id=\"{}\"] focus", window.id);
+    let command = connection
+        .run_command(&command_str)
+        .context("Couldn't communicate with Sway")?;
+    info!("Sending to Sway: {:?}", command);
+    Ok(())
+}


### PR DESCRIPTION
This an alternate approach to supporting Sway, competing with the PR #122

## Old Approach -- Shared Feature

In #122, both Sway and i3 were supported as the the same compile-time feature.
This was done by switching from an i3-specific library to "swayipc", which
supports both window managers.

This maximized shared code, but in practice was difficult to get merged because
the Sway developer didn't test on i3, where it turned to break support. But the i3 developer didn't have Sway installed. The situation meant that in practice it was hard to make changes to support either WM without a risk of breaking the other.

## New Approach -- Seperate Feature

In the new approach, the i3 code is not really touched at all, and should therefore continue to work just as it did before.

Sway is implemented as a separate feature. Now code for either WM can be
updated without a risk of breaking the other.

One challenge with the new approach is each is implemented as a compile-time
feature.

Packagers who need to support both window-managers will need to publish two
packages, like `wmfocus-i3`, `wmfocus-sway`. Depending on which is selected,
the installed `wmfocus` will work with one or the the other.

I'm a beginning Rust developer and don't expect to be able to support them both
at a runtime with this approach, but maybe someone can build on what I've done to make that work.
