### PR TITLE
Feature: Increase y offset when there's overlap.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ fn main() -> Result<()> {
         };
 
         let y_offset = app_config.offset.y;
-        let y = match app_config.vertical_align {
+        let mut y = match app_config.vertical_align {
             args::VerticalAlign::Top => (desktop_window.pos.1 + y_offset) as i16,
             args::VerticalAlign::Center => {
                 (desktop_window.pos.1 + desktop_window.size.1 / 2 - i32::from(height) / 2) as i16
@@ -144,7 +144,10 @@ fn main() -> Result<()> {
             (x.into(), y.into(), width.into(), height.into()),
         );
         while !overlaps.is_empty() {
+            // Move x by the width of the overlap
             x += overlaps.pop().unwrap().2 as i16;
+            // Lower y position to clarify it's not part of parent label.
+            y = y+20 as i16;
             overlaps = utils::find_overlaps(
                 render_windows.values().collect(),
                 (x.into(), y.into(), width.into(), height.into()),


### PR DESCRIPTION
This addresses #145 by adding some vertical offset when labels are next to each other,
clarifying that a child's label is not part of the parent's label.

I don't like that the offset is a fixed number here. I wanted it to be a percentage of the letter's
height. I tried this:

```
y = y+(i32::from(height) / 2) as i16;
```

But that was only right for a single overlap. For multiple-overlaps, the offset for the third
letter was doubled, so it was 100% lower than the one to the left instead of 50% lower.

This patch is also compatible with the most recent Sway branch, PR #138.
