### PR TITLE
Window functions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -307,7 +307,7 @@ fn main() -> Result<()> {
                             if app_config.print_only {
                                 println!("0x{:x}", rw.desktop_window.x_window_id.unwrap_or(0));
                             } else {
-                                wm::send_command_to_window(rw.desktop_window, command)
+                                command.send_to_window(rw.desktop_window)
                                     .context("Couldn't focus window")?;
                             }
                             closed = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,10 +67,10 @@ fn main() -> Result<()> {
     ];
 
     // TODO: Move the ``window_cmd_map`` into the configuration
-    let mut command = &wm::WindowCommand::Focus;
+    let mut window_command = &wm::WindowCommand::Focus;
     let mut window_cmd_map = HashMap::new();
     window_cmd_map.insert("x", wm::WindowCommand::Kill);
-    window_cmd_map.insert("f", wm::WindowCommand::Float);
+    window_cmd_map.insert("q", wm::WindowCommand::Float);
 
     collision_check_window_commands(&window_cmd_map, &app_config.hint_chars)
         .context("Collision in command options and hint chars.")?;
@@ -280,8 +280,8 @@ fn main() -> Result<()> {
                             info!("Adding '{}' to key sequence", kstr);
                             pressed_keys.push_str(kstr);
                         } else if window_cmd_map.contains_key(kstr) {
-                            command = window_cmd_map.get(kstr).unwrap();
-                            info!("Changing command mode to '{command:?}'");
+                            window_command = window_cmd_map.get(kstr).unwrap();
+                            info!("Changing window_command to '{window_command:?}'");
                             continue;
                         } else {
                             warn!("Pressed key '{}' is not a valid hint characters", kstr);
@@ -312,8 +312,8 @@ fn main() -> Result<()> {
                             if app_config.print_only {
                                 println!("0x{:x}", rw.desktop_window.x_window_id.unwrap_or(0));
                             } else {
-                                command.send_to_window(rw.desktop_window)
-                                    .context("Couldn't focus window")?;
+                                window_command.send_to_window(rw.desktop_window)
+                                    .context("Couldn't send window command")?;
                             }
                             closed = true;
                         } else if !pressed_keys.is_empty()

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,9 @@ mod wm_i3;
 #[cfg(feature = "i3")]
 use crate::wm_i3 as wm;
 
+#[cfg(feature = "i3")]
+use crate::utils::sanitise_command_options;
+
 #[derive(Debug)]
 pub struct DesktopWindow {
     id: i64,
@@ -69,6 +72,9 @@ fn main() -> Result<()> {
     let mut command_options = HashMap::new();
     command_options.insert("x", wm::WindowCommand::Kill);
     command_options.insert("f", wm::WindowCommand::Float);
+
+    sanitise_command_options(&command_options, &app_config.hint_chars)
+        .context("Collision in command options and hint chars.")?;
 
     // Assemble RenderWindows from DesktopWindows.
     let mut render_windows = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,7 @@ mod wm_i3;
 #[cfg(feature = "i3")]
 use crate::wm_i3 as wm;
 
-#[cfg(feature = "i3")]
-use crate::utils::sanitise_command_options;
+use crate::utils::collision_check_window_commands;
 
 #[derive(Debug)]
 pub struct DesktopWindow {
@@ -67,13 +66,13 @@ fn main() -> Result<()> {
         (xcb::CW_OVERRIDE_REDIRECT, 1),
     ];
 
-    // TODO: Move the ``command_options`` into the configuration
+    // TODO: Move the ``window_cmd_map`` into the configuration
     let mut command = &wm::WindowCommand::Focus;
-    let mut command_options = HashMap::new();
-    command_options.insert("x", wm::WindowCommand::Kill);
-    command_options.insert("f", wm::WindowCommand::Float);
+    let mut window_cmd_map = HashMap::new();
+    window_cmd_map.insert("x", wm::WindowCommand::Kill);
+    window_cmd_map.insert("f", wm::WindowCommand::Float);
 
-    sanitise_command_options(&command_options, &app_config.hint_chars)
+    collision_check_window_commands(&window_cmd_map, &app_config.hint_chars)
         .context("Collision in command options and hint chars.")?;
 
     // Assemble RenderWindows from DesktopWindows.
@@ -280,8 +279,8 @@ fn main() -> Result<()> {
                         if app_config.hint_chars.contains(kstr) {
                             info!("Adding '{}' to key sequence", kstr);
                             pressed_keys.push_str(kstr);
-                        } else if command_options.contains_key(kstr) {
-                            command = command_options.get(kstr).unwrap();
+                        } else if window_cmd_map.contains_key(kstr) {
+                            command = window_cmd_map.get(kstr).unwrap();
                             info!("Changing command mode to '{command:?}'");
                             continue;
                         } else {

--- a/src/wm_i3.rs
+++ b/src/wm_i3.rs
@@ -116,23 +116,24 @@ pub fn get_windows() -> Result<Vec<DesktopWindow>> {
 pub enum WindowCommand {
     Focus,
     Kill,
-    Float
+    Float,
 }
 
 impl WindowCommand {
-    fn i3_cmd(&self) -> &str {
+    /// Send this command to a window 
+    pub fn send_to_window(&self, window: &DesktopWindow) -> Result<()> {
         match self {
-            WindowCommand::Focus => "focus",
-            WindowCommand::Kill => "kill",
-            WindowCommand::Float => "floating toggle",
+            WindowCommand::Focus => send_command_string(window, "focus"),
+            WindowCommand::Kill => send_command_string(window, "kill"),
+            WindowCommand::Float => send_command_string(window, "floating toggle"),
         }
     }
 }
 
-/// Send a command to a window based on the given ``WindowCommand``.
-pub fn send_command_to_window(window: &DesktopWindow, command: &WindowCommand) -> Result<()> {
+/// Send the given string as an i3 command to the given window.
+fn send_command_string(window: &DesktopWindow, command_str: &str) -> Result<()> {
     let mut connection = I3Connection::connect().context("Couldn't acquire i3 connection")?;
-    let command_str = format!("[con_id=\"{}\"] {}", window.id, command.i3_cmd());
+    let command_str = format!("[con_id=\"{}\"] {}", window.id, command_str);
     let command = connection
         .run_command(&command_str)
         .context("Couldn't communicate with i3")?;

--- a/src/wm_i3.rs
+++ b/src/wm_i3.rs
@@ -120,7 +120,6 @@ pub enum WindowCommand {
 }
 
 impl WindowCommand {
-    /// Send this command to a window 
     pub fn send_to_window(&self, window: &DesktopWindow) -> Result<()> {
         match self {
             WindowCommand::Focus => send_command_string(window, "focus"),
@@ -130,7 +129,7 @@ impl WindowCommand {
     }
 }
 
-/// Send the given string as an i3 command to the given window.
+/// Send the given string as an i3 command to the selected window.
 fn send_command_string(window: &DesktopWindow, command_str: &str) -> Result<()> {
     let mut connection = I3Connection::connect().context("Couldn't acquire i3 connection")?;
     let command_str = format!("[con_id=\"{}\"] {}", window.id, command_str);

--- a/src/wm_i3.rs
+++ b/src/wm_i3.rs
@@ -111,10 +111,28 @@ pub fn get_windows() -> Result<Vec<DesktopWindow>> {
     Ok(windows)
 }
 
-/// Focus a specific `window`.
-pub fn focus_window(window: &DesktopWindow) -> Result<()> {
+/// Possible actions to perform on a window.
+#[derive(Debug)]
+pub enum WindowCommand {
+    Focus,
+    Kill,
+    Float
+}
+
+impl WindowCommand {
+    fn i3_cmd(&self) -> &str {
+        match self {
+            WindowCommand::Focus => "focus",
+            WindowCommand::Kill => "kill",
+            WindowCommand::Float => "floating toggle",
+        }
+    }
+}
+
+/// Send a command to a window based on the given ``WindowCommand``.
+pub fn send_command_to_window(window: &DesktopWindow, command: &WindowCommand) -> Result<()> {
     let mut connection = I3Connection::connect().context("Couldn't acquire i3 connection")?;
-    let command_str = format!("[con_id=\"{}\"] focus", window.id);
+    let command_str = format!("[con_id=\"{}\"] {}", window.id, command.i3_cmd());
     let command = connection
         .run_command(&command_str)
         .context("Couldn't communicate with i3")?;


### PR DESCRIPTION
Implementation of #179 allowing for more complex actions a window, by giving a command key before selecting the window.

Currently, this adds `x` to kill the window and `q` to toggle floating, although this can be extended to much more complex functions. A _full screen_ command and a _split and launch [x]_ seem like good next candidates. 

The main points:

- We add a `WindowCommand` Enum, defining the commands through `WindowCommand.send_to_window()`. If the user gives a key in the `key : WindowCommand` HashMap `window_cmd_map` then we select that command, otherwise we default to `WindowCommand::Focus`. 

- The command keys are currently hard-coded, but if you're happy with the implementation, I'll add something to the command line args. `--kill-window-char [x]` and `--focus-window-char [x]` are pretty verbose, but seem to be the simplest way of allowing the user to configure the keys?

- The Emacs packages used as reference silently ignores any keys used for commands, if they are also present in the `hint_chars`, however, I've decided to make this explicitly return an error, which seems more in line with Rust.


Happy for any other feedback!